### PR TITLE
feat(middleware): JWT トークンサービスの追加とテスト (env 連携)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,8 +765,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1033,6 +1041,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,6 +1171,7 @@ dependencies = [
  "actix-web",
  "argon2",
  "async-trait",
+ "jsonwebtoken",
  "password-hash",
  "rand_core 0.6.4",
  "serde",
@@ -1189,6 +1223,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1341,6 +1385,16 @@ dependencies = [
  "base64ct",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64",
+ "serde",
 ]
 
 [[package]]
@@ -1549,6 +1603,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,6 +1788,18 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.12",
+ "time",
 ]
 
 [[package]]
@@ -2246,6 +2326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,6 +2380,63 @@ name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "whoami"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 thiserror = "1.0"
 async-trait = "0.1"
 serde_json = "1.0"
+jsonwebtoken = "9"

--- a/src/domain/model.rs
+++ b/src/domain/model.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 #[derive(sqlx::FromRow, Debug, Clone)]
 pub struct User {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,5 @@ pub mod app;
 pub mod repository;
 pub mod service;
 pub mod domain;
+pub mod middleware;
 

--- a/src/middleware/auth/mod.rs
+++ b/src/middleware/auth/mod.rs
@@ -1,1 +1,2 @@
 pub mod model;
+pub mod token;

--- a/src/middleware/auth/model.rs
+++ b/src/middleware/auth/model.rs
@@ -6,5 +6,3 @@ pub struct JWTClaim {
     pub iat: i64, // issued at
     pub exp: i64, // expire
 }
-
-

--- a/src/middleware/auth/token.rs
+++ b/src/middleware/auth/token.rs
@@ -1,0 +1,69 @@
+use std::time::{SystemTime, UNIX_EPOCH, Duration};
+
+use jsonwebtoken::{encode, decode, DecodingKey, EncodingKey, Header, Validation};
+use thiserror::Error;
+
+use super::model::JWTClaim;
+
+#[derive(Debug, Error)]
+pub enum TokenError {
+    #[error("encoding error")]
+    Encode,
+    #[error("decoding error")]
+    Decode,
+    #[error("missing JWT_SECRET env")] 
+    MissingSecret,
+    #[error("invalid JWT_EXP_SECS env")] 
+    InvalidExpiration,
+}
+
+pub struct JwtTokenService {
+    encoding: EncodingKey,
+    decoding: DecodingKey,
+    expiration_secs: u64,
+}
+
+impl JwtTokenService {
+    pub fn from_secret(secret: &[u8], expiration_secs: u64) -> Self {
+        Self {
+            encoding: EncodingKey::from_secret(secret),
+            decoding: DecodingKey::from_secret(secret),
+            expiration_secs,
+        }
+    }
+
+    pub fn from_env() -> Result<Self, TokenError> {
+        let secret = std::env::var("JWT_SECRET").map_err(|_| TokenError::MissingSecret)?;
+        let exp = match std::env::var("JWT_EXP_SECS") {
+            Ok(v) => v.parse::<u64>().map_err(|_| TokenError::InvalidExpiration)?,
+            Err(_) => 3600,
+        };
+        Ok(Self::from_secret(secret.as_bytes(), exp))
+    }
+
+    pub fn generate(&self, user_id: i64) -> Result<String, TokenError> {
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or(Duration::from_secs(0)).as_secs() as i64;
+        let claims = JWTClaim {
+            sub: user_id,
+            iat: now,
+            exp: now + self.expiration_secs as i64,
+        };
+        let header = Header::default();
+        encode(&header, &claims, &self.encoding).map_err(|_| TokenError::Encode)
+    }
+
+    pub fn verify(&self, token: &str) -> Result<JWTClaim, TokenError> {
+        let mut validation = Validation::default();
+        validation.validate_exp = true;
+        let claims = decode::<JWTClaim>(token, &self.decoding, &validation)
+            .map(|data| data.claims)
+            .map_err(|_| TokenError::Decode)?;
+
+        // 念のため手動でも exp を検証（バージョン差異対策）
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or(Duration::from_secs(0)).as_secs() as i64;
+        if claims.exp < now { return Err(TokenError::Decode); }
+        Ok(claims)
+    }
+}
+
+

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -84,9 +84,9 @@ impl AuthService for AuthServiceImpl {
             return Err(AuthServiceError::InvalidCredentials);
         };
 
-        // Argon2のPHC文字列をパースして検証
+        // パスワードの検証
         let parsed = PasswordHash::new(&user.password_hash)
-            .map_err(|_| AuthServiceError::InvalidCredentials)?; // PHC文字列のparse
+            .map_err(|_| AuthServiceError::InvalidCredentials)?;
         Argon2::default().verify_password(password.as_bytes(), &parsed)
             .map_err(|_| AuthServiceError::InvalidCredentials)?;
 

--- a/tests/jwt_token.rs
+++ b/tests/jwt_token.rs
@@ -1,0 +1,51 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use memo_app::middleware::auth::model::JWTClaim;
+use memo_app::middleware::auth::token::{JwtTokenService, TokenError};
+
+fn now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+#[test]
+fn generate_and_verify_returns_claim() {
+    let secret = b"secret";
+    let svc = JwtTokenService::from_secret(secret, 3600);
+
+    let token = svc.generate(42).expect("token");
+    let claim = svc.verify(&token).expect("verify");
+
+    assert_eq!(claim.sub, 42);
+    assert!(claim.exp > claim.iat);
+}
+
+#[test]
+fn verify_fails_when_expired() {
+    let secret = b"secret";
+    let svc = JwtTokenService::from_secret(secret, 3600);
+
+    // exp を過去にしたトークンを手動生成
+    let past = now() - 1;
+    let claim = JWTClaim { sub: 1, iat: past - 10, exp: past };
+    let token = encode(&Header::new(Algorithm::HS256), &claim, &EncodingKey::from_secret(secret))
+        .expect("encode");
+
+    let res = svc.verify(&token);
+    assert!(matches!(res, Err(TokenError::Decode)));
+}
+
+#[test]
+fn verify_fails_with_wrong_secret() {
+    let good = JwtTokenService::from_secret(b"good", 3600);
+    let bad = JwtTokenService::from_secret(b"bad", 3600);
+
+    let token = good.generate(7).expect("token");
+    let res = bad.verify(&token);
+    assert!(matches!(res, Err(TokenError::Decode)));
+}
+
+


### PR DESCRIPTION
概要
- JWT トークンサービスを追加し、`middleware` として公開
- 依存追加: jsonwebtoken
- `JwtTokenService` 実装
  - `from_env()` で `JWT_SECRET` (必須) と `JWT_EXP_SECS` (省略時 3600) を読み込み
  - `generate(user_id)` で HS256 トークン発行
  - `verify(token)` で検証 (exp はライブラリ検証 + 手動チェック)
- テスト追加: `tests/jwt_token.rs`
  - 正常系 (生成→検証)
  - 期限切れ
  - 署名不一致

使い方
- 環境変数
  - `JWT_SECRET`: 署名用シークレット (必須)
  - `JWT_EXP_SECS`: 有効期限(秒) デフォルト 3600
- 例: `main.rs` で DI
  ```rust
  use memo_app::middleware::auth::token::JwtTokenService;
  let jwt = JwtTokenService::from_env().expect("jwt config");
  app_data(web::Data::new(jwt))
  ```

注意
- 既存 API への組み込み (ログイン成功時の発行、保護ルートの検証) は次 PR で対応予定。