### PR TITLE
feat(notes): 追加 GET /notes/{id}（公開）、POST /notes、PUT /notes/{id} とテスト

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,2 +1,3 @@
 pub mod model;
 pub mod auth;
+pub mod notes;

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -17,13 +17,13 @@ pub struct LoginOutput {
     pub token: String, // JWT
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 pub struct CreateNoteInput {
     pub title: String,
     pub content: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 pub struct UpdateNoteInput {
     pub title: Option<String>,
     pub content: Option<String>,

--- a/src/app/notes.rs
+++ b/src/app/notes.rs
@@ -1,0 +1,62 @@
+use actix_web::{get, post, put, web, HttpResponse, Responder};
+use std::sync::Arc;
+
+use crate::middleware::auth::extractor::AuthenticatedUser;
+use crate::app::model::CreateNoteInput;
+use crate::repository::note::NoteRepository;
+use crate::app::model::UpdateNoteInput;
+
+#[get("/notes/{id}")]
+pub async fn get_note(
+    note_repo: web::Data<Arc<dyn NoteRepository>>,
+    path: web::Path<i64>,
+) -> impl Responder {
+    let note_id = path.into_inner();
+    match note_repo.find_by_id(note_id).await {
+        Ok(Some(note)) => HttpResponse::Ok().json(note),
+        Ok(None) => HttpResponse::NotFound().finish(),
+        Err(_) => HttpResponse::InternalServerError().finish(),
+    }
+}
+
+#[post("/notes")]
+pub async fn create_note(
+    user: AuthenticatedUser,
+    note_repo: web::Data<Arc<dyn NoteRepository>>,
+    payload: web::Json<CreateNoteInput>,
+) -> impl Responder {
+    match note_repo.create_note(user.0.sub, &payload.title, &payload.content).await {
+        Ok(note) => HttpResponse::Created().json(note),
+        Err(_) => HttpResponse::InternalServerError().finish(),
+    }
+}
+
+#[put("/notes/{id}")]
+pub async fn update_note(
+    user: AuthenticatedUser,
+    note_repo: web::Data<Arc<dyn NoteRepository>>,
+    path: web::Path<i64>,
+    payload: web::Json<UpdateNoteInput>,
+) -> impl Responder {
+    let note_id = path.into_inner();
+    let user_id = user.0.sub;
+    match note_repo
+        .update_note(
+            note_id,
+            user.0.sub,
+            payload.title.as_deref(),
+            payload.content.as_deref(),
+        )
+        .await
+    {
+        Ok(Some(note)) => {
+            if !note.is_owner(user_id) {
+                return HttpResponse::Forbidden().finish();
+            }
+            HttpResponse::Ok().json(note)
+        }
+        Ok(None) => HttpResponse::NotFound().finish(),
+        Err(_) => HttpResponse::InternalServerError().finish(),
+    }
+}
+

--- a/src/domain/model.rs
+++ b/src/domain/model.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
 #[derive(sqlx::FromRow, Debug, Clone)]
 pub struct User {
@@ -8,10 +8,10 @@ pub struct User {
     pub created_at: i64,
 }
 
-#[derive(sqlx::FromRow, Debug, Clone, Serialize)]
+#[derive(sqlx::FromRow, Debug, Clone, Serialize, Deserialize)]
 pub struct Note {
     pub id: i64,
-    pub user_id: i64,
+    pub author_id: i64,
     pub title: String,
     pub content: String,
     pub created_at: i64,

--- a/src/domain/note.rs
+++ b/src/domain/note.rs
@@ -1,0 +1,7 @@
+use crate::domain::model::Note;
+
+impl Note {
+    pub fn is_owner(&self, user_id: i64) -> bool {
+        self.author_id == user_id
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,9 @@ use sqlx::{sqlite::SqlitePoolOptions, SqlitePool};
 use std::sync::Arc;
 
 use app::auth::{signup, login, me};
+use app::notes::{get_note, create_note, update_note};
 use repository::user::{SqliteUserRepository, UserRepository};
+use repository::note::{SqliteNoteRepository, NoteRepository};
 use service::auth::{AuthService, AuthServiceImpl};
 use middleware::auth::token::JwtTokenService;
 
@@ -23,16 +25,21 @@ async fn main() -> std::io::Result<()> {
         .expect("db connect"); 
 
     let user_repo: Arc<dyn UserRepository> = Arc::new(SqliteUserRepository::new(pool.clone()));
+    let note_repo: Arc<dyn NoteRepository> = Arc::new(SqliteNoteRepository::new(pool.clone()));
     let auth_service: Arc<dyn AuthService> = Arc::new(AuthServiceImpl::new(user_repo.clone()));
     let jwt = web::Data::new(JwtTokenService::from_env().expect("JWT config"));
 
     HttpServer::new(move || {
         App::new()
             .app_data(web::Data::new(auth_service.clone()))
+            .app_data(web::Data::new(note_repo.clone()))
             .app_data(jwt.clone())
             .service(signup)
             .service(login)
             .service(me)
+            .service(get_note)
+            .service(create_note)
+            .service(update_note)
     })
     .bind(("127.0.0.1", 8080))?
     .run()

--- a/src/middleware/auth/extractor.rs
+++ b/src/middleware/auth/extractor.rs
@@ -3,10 +3,7 @@ use std::future::{ready, Ready};
 
 use super::{model::JWTClaim, token::JwtTokenService};
 
-pub struct AuthenticatedUser {
-    pub claim: JWTClaim,
-    pub user_id: i64,
-}
+pub struct AuthenticatedUser(pub JWTClaim);
 
 impl FromRequest for AuthenticatedUser {
     type Error = actix_web::Error;
@@ -25,10 +22,7 @@ impl FromRequest for AuthenticatedUser {
         }
 
         match jwt.verify(token) {
-            Ok(claim) => {
-                let user_id = claim.sub;
-                ready(Ok(AuthenticatedUser { claim, user_id }))
-            }
+            Ok(claim) => ready(Ok(AuthenticatedUser(claim))),
             Err(_) => ready(Err(actix_web::error::ErrorUnauthorized("invalid token"))),
         }
     }

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -1,1 +1,2 @@
 pub mod user;
+pub mod note;

--- a/src/repository/note.rs
+++ b/src/repository/note.rs
@@ -1,0 +1,88 @@
+use crate::domain::model::Note;
+use crate::repository::user::RepoError;
+
+#[async_trait::async_trait]
+pub trait NoteRepository: Send + Sync + 'static {
+    async fn create_note(&self, user_id: i64, title: &str, content: &str) -> Result<Note, RepoError>;
+    async fn find_by_id(&self, note_id: i64) -> Result<Option<Note>, RepoError>;
+    async fn update_note(
+        &self,
+        note_id: i64,
+        user_id: i64,
+        title: Option<&str>,
+        content: Option<&str>,
+    ) -> Result<Option<Note>, RepoError>;
+}
+
+use sqlx::SqlitePool;
+
+pub struct SqliteNoteRepository {
+    pub(crate) pool: SqlitePool,
+}
+
+impl SqliteNoteRepository {
+    pub fn new(pool: SqlitePool) -> Self { Self { pool } }
+}
+
+#[async_trait::async_trait]
+impl NoteRepository for SqliteNoteRepository {
+    async fn create_note(&self, user_id: i64, title: &str, content: &str) -> Result<Note, RepoError> {
+        let inserted = sqlx::query_as!(
+            Note,
+            r#"INSERT INTO notes (user_id, title, content, created_at, updated_at)
+               VALUES (?, ?, ?, strftime('%s','now'), strftime('%s','now'))
+               RETURNING id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64""#,
+            user_id,
+            title,
+            content
+        )
+        .fetch_one(&self.pool)
+        .await
+        .map_err(RepoError::DbError)?;
+
+        Ok(inserted)
+    }
+    async fn find_by_id(&self, note_id: i64) -> Result<Option<Note>, RepoError> {
+        let note = sqlx::query_as!(
+            Note,
+            r#"SELECT id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64"
+               FROM notes
+               WHERE id = ?"#,
+            note_id
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(RepoError::DbError)?;
+
+        Ok(note)
+    }
+
+    async fn update_note(
+        &self,
+        note_id: i64,
+        user_id: i64,
+        title: Option<&str>,
+        content: Option<&str>,
+    ) -> Result<Option<Note>, RepoError> {
+        let updated = sqlx::query_as!(
+            Note,
+            r#"UPDATE notes
+               SET title = COALESCE(?, title),
+                   content = COALESCE(?, content),
+                   updated_at = strftime('%s','now')
+               WHERE id = ? AND user_id = ?
+               RETURNING id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64""#,
+            title,
+            content,
+            note_id,
+            user_id
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(RepoError::DbError)?;
+
+        Ok(updated)
+    }
+}
+
+

--- a/tests/notes.rs
+++ b/tests/notes.rs
@@ -1,0 +1,262 @@
+use std::sync::Arc;
+
+use actix_web::{http::StatusCode, test, web, App};
+use async_trait::async_trait;
+use memo_app::app::notes::{create_note, get_note, update_note};
+use memo_app::app::model::{CreateNoteInput, UpdateNoteInput};
+use memo_app::domain::model::Note;
+use memo_app::middleware::auth::token::JwtTokenService;
+use memo_app::repository::note::NoteRepository;
+use memo_app::repository::user::RepoError;
+
+// ---- Mocks ----
+
+struct MockNoteRepoCreateOk;
+
+#[async_trait]
+impl NoteRepository for MockNoteRepoCreateOk {
+    async fn create_note(&self, user_id: i64, title: &str, content: &str) -> Result<Note, RepoError> {
+        Ok(Note {
+            id: 1,
+            author_id: user_id,
+            title: title.to_string(),
+            content: content.to_string(),
+            created_at: 1,
+            updated_at: 1,
+        })
+    }
+
+    async fn find_by_id(&self, _note_id: i64) -> Result<Option<Note>, RepoError> {
+        Ok(None)
+    }
+
+    async fn update_note(
+        &self,
+        _note_id: i64,
+        _user_id: i64,
+        _title: Option<&str>,
+        _content: Option<&str>,
+    ) -> Result<Option<Note>, RepoError> {
+        Ok(None)
+    }
+}
+
+struct MockNoteRepoFindSome;
+
+#[async_trait]
+impl NoteRepository for MockNoteRepoFindSome {
+    async fn create_note(&self, _user_id: i64, _title: &str, _content: &str) -> Result<Note, RepoError> {
+        Err(RepoError::Internal)
+    }
+
+    async fn find_by_id(&self, note_id: i64) -> Result<Option<Note>, RepoError> {
+        Ok(Some(Note {
+            id: note_id,
+            author_id: 7,
+            title: "t".into(),
+            content: "c".into(),
+            created_at: 1,
+            updated_at: 1,
+        }))
+    }
+
+    async fn update_note(
+        &self,
+        _note_id: i64,
+        _user_id: i64,
+        _title: Option<&str>,
+        _content: Option<&str>,
+    ) -> Result<Option<Note>, RepoError> {
+        Ok(None)
+    }
+}
+
+struct MockNoteRepoFindNone;
+
+#[async_trait]
+impl NoteRepository for MockNoteRepoFindNone {
+    async fn create_note(&self, _user_id: i64, _title: &str, _content: &str) -> Result<Note, RepoError> {
+        Err(RepoError::Internal)
+    }
+
+    async fn find_by_id(&self, note_id: i64) -> Result<Option<Note>, RepoError> {
+        Ok(None)
+    }
+
+    async fn update_note(
+        &self,
+        _note_id: i64,
+        _user_id: i64,
+        _title: Option<&str>,
+        _content: Option<&str>,
+    ) -> Result<Option<Note>, RepoError> {
+        Ok(None)
+    }
+}
+
+struct MockNoteRepoUpdateOk;
+
+#[async_trait]
+impl NoteRepository for MockNoteRepoUpdateOk {
+    async fn create_note(&self, _user_id: i64, _title: &str, _content: &str) -> Result<Note, RepoError> {
+        Err(RepoError::Internal)
+    }
+
+    async fn find_by_id(&self, _note_id: i64) -> Result<Option<Note>, RepoError> { Ok(None) }
+
+    async fn update_note(
+        &self,
+        note_id: i64,
+        user_id: i64,
+        title: Option<&str>,
+        content: Option<&str>,
+    ) -> Result<Option<Note>, RepoError> {
+        Ok(Some(Note {
+            id: note_id,
+            author_id: user_id,
+            title: title.unwrap_or("orig").to_string(),
+            content: content.unwrap_or("orig").to_string(),
+            created_at: 1,
+            updated_at: 2,
+        }))
+    }
+}
+
+struct MockNoteRepoUpdateNone;
+
+#[async_trait]
+impl NoteRepository for MockNoteRepoUpdateNone {
+    async fn create_note(&self, _user_id: i64, _title: &str, _content: &str) -> Result<Note, RepoError> { Err(RepoError::Internal) }
+    async fn find_by_id(&self, _note_id: i64) -> Result<Option<Note>, RepoError> { Ok(None) }
+    async fn update_note(
+        &self,
+        _note_id: i64,
+        _user_id: i64,
+        _title: Option<&str>,
+        _content: Option<&str>,
+    ) -> Result<Option<Note>, RepoError> { Ok(None) }
+}
+
+fn jwt() -> JwtTokenService {
+    JwtTokenService::from_secret(b"test-secret", 3600)
+}
+
+// ---- Tests ----
+
+#[actix_web::test]
+async fn create_note_returns_201() {
+    let repo: Arc<dyn NoteRepository> = Arc::new(MockNoteRepoCreateOk);
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(repo))
+            .app_data(web::Data::new(jwt()))
+            .service(create_note),
+    )
+    .await;
+
+    let user_id = 10;
+    let token = jwt().generate(user_id).unwrap();
+    let payload = CreateNoteInput { title: "Hello".into(), content: "World".into() };
+
+    let req = test::TestRequest::post()
+        .uri("/notes")
+        .insert_header(("Authorization", format!("Bearer {}", token)))
+        .set_json(&payload)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let created: Note = test::read_body_json(resp).await;
+    assert_eq!(created.author_id, user_id);
+    assert_eq!(created.title, "Hello");
+    assert_eq!(created.content, "World");
+}
+
+#[actix_web::test]
+async fn get_note_returns_200_public() {
+    let repo: Arc<dyn NoteRepository> = Arc::new(MockNoteRepoFindSome);
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(repo))
+            .service(get_note),
+    )
+    .await;
+
+    let req = test::TestRequest::get().uri("/notes/1").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[actix_web::test]
+async fn get_note_returns_404_when_absent() {
+    let repo: Arc<dyn NoteRepository> = Arc::new(MockNoteRepoFindNone);
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(repo))
+            .service(get_note),
+    )
+    .await;
+
+    let req = test::TestRequest::get().uri("/notes/1").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[actix_web::test]
+async fn update_note_returns_200_for_owner() {
+    let repo: Arc<dyn NoteRepository> = Arc::new(MockNoteRepoUpdateOk);
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(repo))
+            .app_data(web::Data::new(jwt()))
+            .service(update_note),
+    )
+    .await;
+
+    let user_id = 42;
+    let token = jwt().generate(user_id).unwrap();
+    let payload = UpdateNoteInput { title: Some("New".into()), content: None };
+
+    let req = test::TestRequest::put()
+        .uri("/notes/1")
+        .insert_header(("Authorization", format!("Bearer {}", token)))
+        .set_json(&payload)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let updated: Note = test::read_body_json(resp).await;
+    assert_eq!(updated.id, 1);
+    assert_eq!(updated.author_id, user_id);
+    assert_eq!(updated.title, "New");
+}
+
+#[actix_web::test]
+async fn update_note_returns_404_when_not_owner_or_absent() {
+    let repo: Arc<dyn NoteRepository> = Arc::new(MockNoteRepoUpdateNone);
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(repo))
+            .app_data(web::Data::new(jwt()))
+            .service(update_note),
+    )
+    .await;
+
+    let token = jwt().generate(99).unwrap();
+    let payload = UpdateNoteInput { title: None, content: Some("C".into()) };
+
+    let req = test::TestRequest::put()
+        .uri("/notes/2")
+        .insert_header(("Authorization", format!("Bearer {}", token)))
+        .set_json(&payload)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+


### PR DESCRIPTION
このPRでは、ノート機能の基本エンドポイントを追加します。

変更概要:
- app
  - GET /notes/{id}: 認証不要で公開取得
  - POST /notes: 認証必須、作成（201）
  - PUT /notes/{id}: 認証必須、所有者のみ更新（200）
- domain
  - Note へ Deserialize を付与
  - 所有者判定ヘルパー `Note::is_owner` を追加
- repository
  - NoteRepository（create/find_by_id/update）を追加し、SQLite実装を実装
- tests
  - GET公開/404、POST作成、PUT更新のテストを追加
- auth
  - `AuthenticatedUser` をタプル構造体化（エクストラクタのエラー解消）

環境・補足:
- DB: SQLite（マイグレーションは既存の `db/migrations` を使用）
- ビルド/リンターはローカルでOK

ご確認よろしくお願いします。