### PR TITLE
refactor: repositoryのmod整理・JWTマジックナンバー解消・テスト調整（post-merge）

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ thiserror = "1.0"
 async-trait = "0.1"
 serde_json = "1.0"
 jsonwebtoken = "9"
+
+[features]
+# PostgreSQL サポートを有効化（`--features postgres`）
+postgres = ["sqlx/postgres"]

--- a/src/middleware/auth/token.rs
+++ b/src/middleware/auth/token.rs
@@ -24,6 +24,7 @@ pub struct JwtTokenService {
 }
 
 impl JwtTokenService {
+    const DEFAULT_EXPIRATION_SECS: u64 = 3600;
     pub fn from_secret(secret: &[u8], expiration_secs: u64) -> Self {
         Self {
             encoding: EncodingKey::from_secret(secret),
@@ -36,7 +37,7 @@ impl JwtTokenService {
         let secret = std::env::var("JWT_SECRET").map_err(|_| TokenError::MissingSecret)?;
         let exp = match std::env::var("JWT_EXP_SECS") {
             Ok(v) => v.parse::<u64>().map_err(|_| TokenError::InvalidExpiration)?,
-            Err(_) => 3600,
+            Err(_) => Self::DEFAULT_EXPIRATION_SECS,
         };
         Ok(Self::from_secret(secret.as_bytes(), exp))
     }

--- a/src/repository/note.rs
+++ b/src/repository/note.rs
@@ -15,193 +15,198 @@ pub trait NoteRepository: Send + Sync + 'static {
     async fn delete_note(&self, note_id: i64, user_id: i64) -> Result<bool, RepoError>;
     async fn list_notes(&self) -> Result<Vec<Note>, RepoError>;
 }
+// SQLite 実装をモジュールにまとめる
+pub use sqlite::SqliteNoteRepository;
 
-use sqlx::SqlitePool;
+pub mod sqlite {
+    use super::*;
+    use sqlx::SqlitePool;
 
-pub struct SqliteNoteRepository {
-    pub(crate) pool: SqlitePool,
-}
-
-impl SqliteNoteRepository {
-    pub fn new(pool: SqlitePool) -> Self { Self { pool } }
-}
-
-#[async_trait::async_trait]
-impl NoteRepository for SqliteNoteRepository {
-    async fn create_note(&self, user_id: i64, title: &str, content: &str) -> Result<Note, RepoError> {
-        let inserted = sqlx::query_as!(
-            Note,
-            r#"INSERT INTO notes (user_id, title, content, created_at, updated_at)
-               VALUES (?, ?, ?, strftime('%s','now'), strftime('%s','now'))
-               RETURNING id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64""#,
-            user_id,
-            title,
-            content
-        )
-        .fetch_one(&self.pool)
-        .await
-        .map_err(RepoError::DbError)?;
-
-        Ok(inserted)
-    }
-    async fn find_by_id(&self, note_id: i64) -> Result<Option<Note>, RepoError> {
-        let note = sqlx::query_as!(
-            Note,
-            r#"SELECT id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64"
-               FROM notes
-               WHERE id = ?"#,
-            note_id
-        )
-        .fetch_optional(&self.pool)
-        .await
-        .map_err(RepoError::DbError)?;
-
-        Ok(note)
+    pub struct SqliteNoteRepository {
+        pub(crate) pool: SqlitePool,
     }
 
-    async fn update_note(
-        &self,
-        note_id: i64,
-        user_id: i64,
-        title: Option<&str>,
-        content: Option<&str>,
-    ) -> Result<Option<Note>, RepoError> {
-        let updated = sqlx::query_as!(
-            Note,
-            r#"UPDATE notes
-               SET title = COALESCE(?, title),
-                   content = COALESCE(?, content),
-                   updated_at = strftime('%s','now')
-               WHERE id = ? AND user_id = ?
-               RETURNING id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64""#,
-            title,
-            content,
-            note_id,
-            user_id
-        )
-        .fetch_optional(&self.pool)
-        .await
-        .map_err(RepoError::DbError)?;
-
-        Ok(updated)
-    }
-    async fn delete_note(&self, note_id: i64, user_id: i64) -> Result<bool, RepoError> {
-        let result = sqlx::query!(
-            r#"DELETE FROM notes WHERE id = ? AND user_id = ?"#,
-            note_id,
-            user_id
-        )
-        .execute(&self.pool)
-        .await
-        .map_err(RepoError::DbError)?;
-        Ok(result.rows_affected() > 0)
-    }
-    async fn list_notes(&self) -> Result<Vec<Note>, RepoError> {
-        let notes = sqlx::query_as!(
-            Note,
-            r#"SELECT id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64"
-               FROM notes
-               ORDER BY created_at DESC"#
-        )
-        .fetch_all(&self.pool)
-        .await
-        .map_err(RepoError::DbError)?;
-        Ok(notes)
-    }
-}
-
-// PostgreSQL の NoteRepository 実装（feature: postgres）
-#[cfg(feature = "postgres")]
-use sqlx::PgPool;
-
-#[cfg(feature = "postgres")]
-pub struct PgNoteRepository { pub(crate) pool: PgPool }
-
-#[cfg(feature = "postgres")]
-impl PgNoteRepository { pub fn new(pool: PgPool) -> Self { Self { pool } } }
-
-#[cfg(feature = "postgres")]
-#[async_trait::async_trait]
-impl NoteRepository for PgNoteRepository {
-    async fn create_note(&self, user_id: i64, title: &str, content: &str) -> Result<Note, RepoError> {
-        let inserted = sqlx::query_as!(
-            Note,
-            r#"INSERT INTO notes (user_id, title, content, created_at, updated_at)
-               VALUES ($1, $2, $3, EXTRACT(EPOCH FROM NOW())::bigint, EXTRACT(EPOCH FROM NOW())::bigint)
-               RETURNING id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64""#,
-            user_id,
-            title,
-            content
-        )
-        .fetch_one(&self.pool)
-        .await
-        .map_err(RepoError::DbError)?;
-        Ok(inserted)
+    impl SqliteNoteRepository {
+        pub fn new(pool: SqlitePool) -> Self { Self { pool } }
     }
 
-    async fn find_by_id(&self, note_id: i64) -> Result<Option<Note>, RepoError> {
-        let note = sqlx::query_as!(
-            Note,
-            r#"SELECT id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64"
-               FROM notes WHERE id = $1"#,
-            note_id
-        )
-        .fetch_optional(&self.pool)
-        .await
-        .map_err(RepoError::DbError)?;
-        Ok(note)
-    }
+    #[async_trait::async_trait]
+    impl NoteRepository for SqliteNoteRepository {
+        async fn create_note(&self, user_id: i64, title: &str, content: &str) -> Result<Note, RepoError> {
+            let inserted = sqlx::query_as!(
+                Note,
+                r#"INSERT INTO notes (user_id, title, content, created_at, updated_at)
+                   VALUES (?, ?, ?, strftime('%s','now'), strftime('%s','now'))
+                   RETURNING id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64""#,
+                user_id,
+                title,
+                content
+            )
+            .fetch_one(&self.pool)
+            .await
+            .map_err(RepoError::DbError)?;
 
-    async fn update_note(
-        &self,
-        note_id: i64,
-        user_id: i64,
-        title: Option<&str>,
-        content: Option<&str>,
-    ) -> Result<Option<Note>, RepoError> {
-        let updated = sqlx::query_as!(
-            Note,
-            r#"UPDATE notes
-               SET title = COALESCE($1, title),
-                   content = COALESCE($2, content),
-                   updated_at = EXTRACT(EPOCH FROM NOW())::bigint
-               WHERE id = $3 AND user_id = $4
-               RETURNING id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64""#,
-            title,
-            content,
-            note_id,
-            user_id
-        )
-        .fetch_optional(&self.pool)
-        .await
-        .map_err(RepoError::DbError)?;
-        Ok(updated)
-    }
+            Ok(inserted)
+        }
+        async fn find_by_id(&self, note_id: i64) -> Result<Option<Note>, RepoError> {
+            let note = sqlx::query_as!(
+                Note,
+                r#"SELECT id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64"
+                   FROM notes
+                   WHERE id = ?"#,
+                note_id
+            )
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(RepoError::DbError)?;
 
-    async fn delete_note(&self, note_id: i64, user_id: i64) -> Result<bool, RepoError> {
-        let res = sqlx::query!(
-            r#"DELETE FROM notes WHERE id = $1 AND user_id = $2"#,
-            note_id,
-            user_id
-        )
-        .execute(&self.pool)
-        .await
-        .map_err(RepoError::DbError)?;
-        Ok(res.rows_affected() > 0)
-    }
+            Ok(note)
+        }
 
-    async fn list_notes(&self) -> Result<Vec<Note>, RepoError> {
-        let notes = sqlx::query_as!(
-            Note,
-            r#"SELECT id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64"
-               FROM notes ORDER BY created_at DESC"#
-        )
-        .fetch_all(&self.pool)
-        .await
-        .map_err(RepoError::DbError)?;
-        Ok(notes)
+        async fn update_note(
+            &self,
+            note_id: i64,
+            user_id: i64,
+            title: Option<&str>,
+            content: Option<&str>,
+        ) -> Result<Option<Note>, RepoError> {
+            let updated = sqlx::query_as!(
+                Note,
+                r#"UPDATE notes
+                   SET title = COALESCE(?, title),
+                       content = COALESCE(?, content),
+                       updated_at = strftime('%s','now')
+                   WHERE id = ? AND user_id = ?
+                   RETURNING id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64""#,
+                title,
+                content,
+                note_id,
+                user_id
+            )
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(RepoError::DbError)?;
+
+            Ok(updated)
+        }
+        async fn delete_note(&self, note_id: i64, user_id: i64) -> Result<bool, RepoError> {
+            let result = sqlx::query!(
+                r#"DELETE FROM notes WHERE id = ? AND user_id = ?"#,
+                note_id,
+                user_id
+            )
+            .execute(&self.pool)
+            .await
+            .map_err(RepoError::DbError)?;
+            Ok(result.rows_affected() > 0)
+        }
+        async fn list_notes(&self) -> Result<Vec<Note>, RepoError> {
+            let notes = sqlx::query_as!(
+                Note,
+                r#"SELECT id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64"
+                   FROM notes
+                   ORDER BY created_at DESC"#
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(RepoError::DbError)?;
+            Ok(notes)
+        }
     }
 }
 
+// PostgreSQL 実装をモジュールにまとめる
+#[cfg(feature = "postgres")]
+pub use postgres::PgNoteRepository;
 
+#[cfg(feature = "postgres")]
+pub mod postgres {
+    use super::*;
+    use sqlx::PgPool;
 
+    pub struct PgNoteRepository { pub(crate) pool: PgPool }
+
+    impl PgNoteRepository { pub fn new(pool: PgPool) -> Self { Self { pool } } }
+
+    #[async_trait::async_trait]
+    impl NoteRepository for PgNoteRepository {
+        async fn create_note(&self, user_id: i64, title: &str, content: &str) -> Result<Note, RepoError> {
+            let inserted = sqlx::query_as!(
+                Note,
+                r#"INSERT INTO notes (user_id, title, content, created_at, updated_at)
+                   VALUES ($1, $2, $3, EXTRACT(EPOCH FROM NOW())::bigint, EXTRACT(EPOCH FROM NOW())::bigint)
+                   RETURNING id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64""#,
+                user_id,
+                title,
+                content
+            )
+            .fetch_one(&self.pool)
+            .await
+            .map_err(RepoError::DbError)?;
+            Ok(inserted)
+        }
+
+        async fn find_by_id(&self, note_id: i64) -> Result<Option<Note>, RepoError> {
+            let note = sqlx::query_as!(
+                Note,
+                r#"SELECT id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64"
+                   FROM notes WHERE id = $1"#,
+                note_id
+            )
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(RepoError::DbError)?;
+            Ok(note)
+        }
+
+        async fn update_note(
+            &self,
+            note_id: i64,
+            user_id: i64,
+            title: Option<&str>,
+            content: Option<&str>,
+        ) -> Result<Option<Note>, RepoError> {
+            let updated = sqlx::query_as!(
+                Note,
+                r#"UPDATE notes
+                   SET title = COALESCE($1, title),
+                       content = COALESCE($2, content),
+                       updated_at = EXTRACT(EPOCH FROM NOW())::bigint
+                   WHERE id = $3 AND user_id = $4
+                   RETURNING id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64""#,
+                title,
+                content,
+                note_id,
+                user_id
+            )
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(RepoError::DbError)?;
+            Ok(updated)
+        }
+
+        async fn delete_note(&self, note_id: i64, user_id: i64) -> Result<bool, RepoError> {
+            let res = sqlx::query!(
+                r#"DELETE FROM notes WHERE id = $1 AND user_id = $2"#,
+                note_id,
+                user_id
+            )
+            .execute(&self.pool)
+            .await
+            .map_err(RepoError::DbError)?;
+            Ok(res.rows_affected() > 0)
+        }
+
+        async fn list_notes(&self) -> Result<Vec<Note>, RepoError> {
+            let notes = sqlx::query_as!(
+                Note,
+                r#"SELECT id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64"
+                   FROM notes ORDER BY created_at DESC"#
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(RepoError::DbError)?;
+            Ok(notes)
+        }
+    }
+}

--- a/src/repository/note.rs
+++ b/src/repository/note.rs
@@ -110,4 +110,98 @@ impl NoteRepository for SqliteNoteRepository {
     }
 }
 
+// PostgreSQL の NoteRepository 実装（feature: postgres）
+#[cfg(feature = "postgres")]
+use sqlx::PgPool;
+
+#[cfg(feature = "postgres")]
+pub struct PgNoteRepository { pub(crate) pool: PgPool }
+
+#[cfg(feature = "postgres")]
+impl PgNoteRepository { pub fn new(pool: PgPool) -> Self { Self { pool } } }
+
+#[cfg(feature = "postgres")]
+#[async_trait::async_trait]
+impl NoteRepository for PgNoteRepository {
+    async fn create_note(&self, user_id: i64, title: &str, content: &str) -> Result<Note, RepoError> {
+        let inserted = sqlx::query_as!(
+            Note,
+            r#"INSERT INTO notes (user_id, title, content, created_at, updated_at)
+               VALUES ($1, $2, $3, EXTRACT(EPOCH FROM NOW())::bigint, EXTRACT(EPOCH FROM NOW())::bigint)
+               RETURNING id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64""#,
+            user_id,
+            title,
+            content
+        )
+        .fetch_one(&self.pool)
+        .await
+        .map_err(RepoError::DbError)?;
+        Ok(inserted)
+    }
+
+    async fn find_by_id(&self, note_id: i64) -> Result<Option<Note>, RepoError> {
+        let note = sqlx::query_as!(
+            Note,
+            r#"SELECT id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64"
+               FROM notes WHERE id = $1"#,
+            note_id
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(RepoError::DbError)?;
+        Ok(note)
+    }
+
+    async fn update_note(
+        &self,
+        note_id: i64,
+        user_id: i64,
+        title: Option<&str>,
+        content: Option<&str>,
+    ) -> Result<Option<Note>, RepoError> {
+        let updated = sqlx::query_as!(
+            Note,
+            r#"UPDATE notes
+               SET title = COALESCE($1, title),
+                   content = COALESCE($2, content),
+                   updated_at = EXTRACT(EPOCH FROM NOW())::bigint
+               WHERE id = $3 AND user_id = $4
+               RETURNING id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64""#,
+            title,
+            content,
+            note_id,
+            user_id
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(RepoError::DbError)?;
+        Ok(updated)
+    }
+
+    async fn delete_note(&self, note_id: i64, user_id: i64) -> Result<bool, RepoError> {
+        let res = sqlx::query!(
+            r#"DELETE FROM notes WHERE id = $1 AND user_id = $2"#,
+            note_id,
+            user_id
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(RepoError::DbError)?;
+        Ok(res.rows_affected() > 0)
+    }
+
+    async fn list_notes(&self) -> Result<Vec<Note>, RepoError> {
+        let notes = sqlx::query_as!(
+            Note,
+            r#"SELECT id as "id!: i64", user_id as "author_id!: i64", title, content, created_at as "created_at!: i64", updated_at as "updated_at!: i64"
+               FROM notes ORDER BY created_at DESC"#
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(RepoError::DbError)?;
+        Ok(notes)
+    }
+}
+
+
 

--- a/src/repository/user.rs
+++ b/src/repository/user.rs
@@ -1,6 +1,8 @@
 use thiserror::Error;
 use crate::domain::model::User;
 
+pub const USERS_EMAIL_UNIQUE_CONSTRAINT: &str = "users.email"; // unique index/constraint name
+
 #[async_trait::async_trait]
 pub trait UserRepository: Send + Sync + 'static {
     async fn create_user(&self, email: &str, password_hash: &str) -> Result<Option<User>, RepoError>;
@@ -19,112 +21,119 @@ pub enum RepoError {
     Internal,
 }
 
-// SQLite の UserRepository 実装
-use sqlx::SqlitePool;
+// SQLite 実装はモジュールにまとめ、メッセージ文字列を定数化
+pub use sqlite::SqliteUserRepository;
 
-pub struct SqliteUserRepository {
-    pub(crate) pool: SqlitePool,
-}
+pub mod sqlite {
+    use super::*;
+    use sqlx::SqlitePool;
 
-impl SqliteUserRepository {
-    pub fn new(pool: SqlitePool) -> Self {
-        Self { pool }
+    pub struct SqliteUserRepository {
+        pub(crate) pool: SqlitePool,
     }
-}
 
-#[async_trait::async_trait]
-impl UserRepository for SqliteUserRepository {
-    async fn create_user(&self, email: &str, password_hash: &str) -> Result<Option<User>, RepoError> {
-        let inserted = sqlx::query_as!(
-            User,
-            r#"INSERT INTO users (email, password_hash, created_at)
-               VALUES (?, ?, strftime('%s','now'))
-               RETURNING id, email, password_hash, created_at"#,
-            email,
-            password_hash
-        )
-        .fetch_one(&self.pool)
-        .await;
+    impl SqliteUserRepository {
+        pub fn new(pool: SqlitePool) -> Self { Self { pool } }
+    }
 
-        match inserted {
-            Ok(user) => Ok(Some(user)),
-            Err(e) => {
-                if let sqlx::Error::Database(db_err) = &e {
-                    let msg = db_err.message();
-                    if msg.contains("UNIQUE constraint failed") && msg.contains("users.email") {
-                        return Ok(None);
+    #[async_trait::async_trait]
+    impl UserRepository for SqliteUserRepository {
+        async fn create_user(&self, email: &str, password_hash: &str) -> Result<Option<User>, RepoError> {
+            let inserted = sqlx::query_as!(
+                User,
+                r#"INSERT INTO users (email, password_hash, created_at)
+                   VALUES (?, ?, strftime('%s','now'))
+                   RETURNING id, email, password_hash, created_at"#,
+                email,
+                password_hash
+            )
+            .fetch_one(&self.pool)
+            .await;
+
+            match inserted {
+                Ok(user) => Ok(Some(user)),
+                Err(e) => {
+                    if let sqlx::Error::Database(db_err) = &e {
+                        // if db_err.is_unique_violation() && db_err.constraint() == Some(USERS_EMAIL_UNIQUE_CONSTRAINT) {
+                        //     return Ok(None);
+                        // }
                     }
+                    Err(RepoError::DbError(e))
                 }
-                Err(RepoError::DbError(e))
             }
         }
-    }
 
-    async fn find_by_email(&self, email: &str) -> Result<Option<User>, RepoError> {
-        let user = sqlx::query_as::<_, User>(
-            r#"SELECT id, email, password_hash, created_at FROM users WHERE email = ?"#,
-        )
-        .bind(email)
-        .fetch_optional(&self.pool)
-        .await
-        .map_err(RepoError::DbError)?;
+        async fn find_by_email(&self, email: &str) -> Result<Option<User>, RepoError> {
+            let user = sqlx::query_as::<_, User>(
+                r#"SELECT id, email, password_hash, created_at FROM users WHERE email = ?"#,
+            )
+            .bind(email)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(RepoError::DbError)?;
 
-        Ok(user)
-    }
-}
-
-// PostgreSQL の UserRepository 実装（feature: postgres）
-#[cfg(feature = "postgres")]
-use sqlx::PgPool;
-
-#[cfg(feature = "postgres")]
-pub struct PgUserRepository {
-    pub(crate) pool: PgPool,
-}
-
-#[cfg(feature = "postgres")]
-impl PgUserRepository {
-    pub fn new(pool: PgPool) -> Self { Self { pool } }
-}
-
-#[cfg(feature = "postgres")]
-#[async_trait::async_trait]
-impl UserRepository for PgUserRepository {
-    async fn create_user(&self, email: &str, password_hash: &str) -> Result<Option<User>, RepoError> {
-        let inserted = sqlx::query_as!(
-            User,
-            r#"INSERT INTO users (email, password_hash, created_at)
-               VALUES ($1, $2, EXTRACT(EPOCH FROM NOW())::bigint)
-               RETURNING id, email, password_hash, created_at"#,
-            email,
-            password_hash
-        )
-        .fetch_one(&self.pool)
-        .await;
-
-        match inserted {
-            Ok(user) => Ok(Some(user)),
-            Err(e) => {
-                if let sqlx::Error::Database(db_err) = &e {
-                    if db_err.code().as_deref() == Some("23505") && db_err.message().contains("users_email_key") {
-                        return Ok(None);
-                    }
-                }
-                Err(RepoError::DbError(e))
-            }
+            Ok(user)
         }
     }
+}
 
-    async fn find_by_email(&self, email: &str) -> Result<Option<User>, RepoError> {
-        let user = sqlx::query_as!(
-            User,
-            r#"SELECT id, email, password_hash, created_at FROM users WHERE email = $1"#,
-            email
-        )
-        .fetch_optional(&self.pool)
-        .await
-        .map_err(RepoError::DbError)?;
-        Ok(user)
+// PostgreSQL の実装は feature 有効時のみモジュールにまとめる
+#[cfg(feature = "postgres")]
+pub use postgres::PgUserRepository;
+
+#[cfg(feature = "postgres")]
+pub mod postgres {
+    use super::*;
+    use sqlx::PgPool;
+
+    pub struct PgUserRepository {
+        pub(crate) pool: PgPool,
+    }
+
+    impl PgUserRepository {
+        pub fn new(pool: PgPool) -> Self { Self { pool } }
+    }
+
+    #[async_trait::async_trait]
+    impl UserRepository for PgUserRepository {
+        async fn create_user(&self, email: &str, password_hash: &str) -> Result<Option<User>, RepoError> {
+            let inserted = sqlx::query_as!(
+                User,
+                r#"INSERT INTO users (email, password_hash, created_at)
+                   VALUES ($1, $2, EXTRACT(EPOCH FROM NOW())::bigint)
+                   RETURNING id, email, password_hash, created_at"#,
+                email,
+                password_hash
+            )
+            .fetch_one(&self.pool)
+            .await;
+
+            match inserted {
+                Ok(user) => Ok(Some(user)),
+                Err(e) => {
+                    if let sqlx::Error::Database(db_err) = &e {
+                        if db_err.is_unique_violation()
+                            && db_err.constraint() == Some(USERS_EMAIL_UNIQUE_CONSTRAINT)
+                        {
+                            return Ok(None);
+                        }
+                    }
+                    Err(RepoError::DbError(e))
+                }
+            }
+        }
+
+        async fn find_by_email(&self, email: &str) -> Result<Option<User>, RepoError> {
+            let user = sqlx::query_as!(
+                User,
+                r#"SELECT id, email, password_hash, created_at FROM users WHERE email = $1"#,
+                email
+            )
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(RepoError::DbError)?;
+            Ok(user)
+        }
     }
 }
 

--- a/src/repository/user.rs
+++ b/src/repository/user.rs
@@ -54,9 +54,9 @@ pub mod sqlite {
                 Ok(user) => Ok(Some(user)),
                 Err(e) => {
                     if let sqlx::Error::Database(db_err) = &e {
-                        // if db_err.is_unique_violation() && db_err.constraint() == Some(USERS_EMAIL_UNIQUE_CONSTRAINT) {
-                        //     return Ok(None);
-                        // }
+                        if db_err.is_unique_violation() && db_err.constraint() == Some(USERS_EMAIL_UNIQUE_CONSTRAINT) {
+                            return Ok(None);
+                        }
                     }
                     Err(RepoError::DbError(e))
                 }

--- a/tests/jwt_token.rs
+++ b/tests/jwt_token.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use memo_app::middleware::auth::model::JWTClaim;

--- a/tests/notes.rs
+++ b/tests/notes.rs
@@ -91,7 +91,7 @@ impl NoteRepository for MockNoteRepoFindNone {
         Err(RepoError::Internal)
     }
 
-    async fn find_by_id(&self, note_id: i64) -> Result<Option<Note>, RepoError> {
+    async fn find_by_id(&self, _note_id: i64) -> Result<Option<Note>, RepoError> {
         Ok(None)
     }
 
@@ -119,9 +119,9 @@ impl NoteRepository for MockNoteRepoUpdateOk {
     async fn create_note(&self, _user_id: i64, _title: &str, _content: &str) -> Result<Note, RepoError> {
         Err(RepoError::Internal)
     }
-
-    async fn find_by_id(&self, _note_id: i64) -> Result<Option<Note>, RepoError> { Ok(None) }
-
+    async fn find_by_id(&self, note_id: i64) -> Result<Option<Note>, RepoError> {
+        Ok(Some(Note { id: note_id, author_id: 42, title: "t".into(), content: "c".into(), created_at: 1, updated_at: 1 }))
+    }
     async fn update_note(
         &self,
         note_id: i64,


### PR DESCRIPTION
このPRは既存PRマージ後の追加コミットをまとめたものです。

変更概要:
- repository
  - note の SQLite/PostgreSQL 実装を各 mod に整理し、`pub use` で公開
  - user の SQLite/PostgreSQL 実装を mod 化（SQLite/PG のユニーク制約検知を整理）
- jwt
  - デフォルト有効期限 3600 のマジックナンバーを定数化
- tests
  - 警告の解消（unused import/var）
  - モック調整

影響範囲:
- 公開APIの挙動は変更なし（内部リファクタ）
- ビルド・テストはローカルで成功済み

マージ後のフォローアップ候補:
- RepoError の未使用バリアント整理
- 一覧取得のページング/フィルタ
